### PR TITLE
Update to latest `fixed-spotify-open-api.yml`

### DIFF
--- a/spotify-graphql-schema-generator/fixed-spotify-open-api.yml
+++ b/spotify-graphql-schema-generator/fixed-spotify-open-api.yml
@@ -8,7 +8,7 @@ info:
     The base URI for all Web API requests is `https://api.spotify.com/v1`.
 
     Need help? See our <a href="https://developer.spotify.com/documentation/web-api/guides/">Web API guides</a> for more information, or visit the <a href="https://community.spotify.com/t5/Spotify-for-Developers/bd-p/Spotify_Developer">Spotify for Developers community forum</a> to ask questions and connect with other developers.
-  version: 2022.9.4
+  version: 2022.9.27
   title: Spotify Web API with fixes and improvements from sonallux
   termsOfService: https://developer.spotify.com/terms/
   contact:
@@ -407,6 +407,118 @@ paths:
       security:
         - oauth_2_0:
             - user-read-playback-position
+  /audiobooks/{id}:
+    x-spotify-docs-display-name: audiobook
+    x-spotify-docs-category: Audiobooks
+    get:
+      operationId: get-an-audiobook
+      tags:
+        - Audiobooks
+      x-spotify-docs-endpoint-name: Get an Audiobook
+      x-spotify-docs-console-url: /console/get-audiobook/?id=5thw29eqjomhIDMY1XKsLk
+      summary: |
+        Get an Audiobook
+      description: |
+        Get Spotify catalog information for a single audiobook.<br />
+        **Note: Audiobooks are only available for the US market.**
+      parameters:
+        - $ref: '#/components/parameters/PathAudiobookId'
+        - $ref: '#/components/parameters/QueryMarket'
+      responses:
+        "200":
+          $ref: '#/components/responses/OneAudiobook'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        "429":
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - oauth_2_0: [ ]
+  /audiobooks:
+    x-spotify-docs-display-name: several-audiobooks
+    x-spotify-docs-category: Audiobooks
+    get:
+      operationId: get-multiple-audiobooks
+      tags:
+        - Audiobooks
+      x-spotify-docs-endpoint-name: Get Several Audiobooks
+      x-spotify-docs-console-url: "/console/get-several-audiobooks/?ids=5thw29eqjomhIDMY1XKsLk,2IEBhnu61ieYGFRPEJIO40"
+      summary: |
+        Get Several Audiobooks
+      description: |
+        Get Spotify catalog information for several audiobooks identified by their Spotify IDs.<br />
+        **Note: Audiobooks are only available for the US market.**
+      parameters:
+        - $ref: '#/components/parameters/QueryAudiobookIds'
+        - $ref: '#/components/parameters/QueryMarket'
+      responses:
+        "200":
+          $ref: '#/components/responses/ManyAudiobooks'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        "429":
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - oauth_2_0: [ ]
+  /chapters/{id}:
+    x-spotify-docs-display-name: chapters
+    x-spotify-docs-category: Chapters
+    get:
+      operationId: get-a-chapter
+      tags:
+        - Chapters
+      x-spotify-docs-endpoint-name: Get a Chapter
+      x-spotify-docs-console-url: /console/get-chapter/?id=2i47HuOBSV2XaJNy0NCZXM
+      summary: |
+        Get a Chapter
+      description: |
+        Get Spotify catalog information for a single chapter.<br />
+        **Note: Chapters are only available for the US market.**
+      parameters:
+        - $ref: '#/components/parameters/PathChapterId'
+        - $ref: '#/components/parameters/QueryMarket'
+      responses:
+        "200":
+          $ref: '#/components/responses/OneChapter'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        "429":
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - oauth_2_0: [ ]
+  /chapters:
+    x-spotify-docs-display-name: several-chapters
+    x-spotify-docs-category: Chapters
+    get:
+      operationId: get-several-chapters
+      tags:
+        - Chapters
+      x-spotify-docs-endpoint-name: Get Several Chapters
+      x-spotify-docs-console-url: "/console/get-several-chapters/?ids=2i47HuOBSV2XaJNy0NCZXM,2GUbORsUnP1qVVlLwd9DzP"
+      summary: |
+        Get Several Chapters
+      description: |
+        Get Spotify catalog information for several chapters identified by their Spotify IDs.<br />
+        **Note: Chapters are only available for the US market.**
+      parameters:
+        - $ref: '#/components/parameters/QueryChapterIds'
+        - $ref: '#/components/parameters/QueryMarket'
+      responses:
+        "200":
+          $ref: '#/components/responses/ManyChapters'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        "429":
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - oauth_2_0: [ ]
   /tracks/{id}:
     x-spotify-docs-display-name: track
     x-spotify-docs-category: Tracks
@@ -483,8 +595,9 @@ paths:
       summary: |
         Search for Item
       description: |
-        Get Spotify catalog information about albums, artists, playlists, tracks, shows or episodes
-        that match a keyword string.
+        Get Spotify catalog information about albums, artists, playlists, tracks, shows, episodes or audiobooks
+        that match a keyword string.<br />
+        **Note: Audiobooks are only available for the US market.**
       parameters:
         - name: q
           required: true
@@ -524,6 +637,7 @@ paths:
                 - track
                 - show
                 - episode
+                - audiobook
         - $ref: '#/components/parameters/QueryMarket'
         - name: limit
           required: false
@@ -3692,6 +3806,32 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/AlbumObject'
+    ManyAudiobooks:
+      description: A set of audiobooks
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - audiobooks
+            properties:
+              audiobooks:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AudiobookObject'
+    ManyChapters:
+      description: A set of chapters
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - chapters
+            properties:
+              chapters:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChapterObject'
     ManyDevices:
       description: A set of devices
       content:
@@ -3838,6 +3978,18 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/EpisodeObject'
+    OneChapter:
+      description: A Chapter
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ChapterObject'
+    OneAudiobook:
+      description: An Audiobook
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AudiobookObject'
     OneAlbum:
       description: An album
       content:
@@ -3957,6 +4109,8 @@ components:
                 $ref: '#/components/schemas/ShowsPagingObject'
               episodes:
                 $ref: '#/components/schemas/EpisodesPagingObject'
+              audiobooks:
+                $ref: '#/components/schemas/AudiobooksPagingObject'
     OneRecommendations:
       description: A set of recommendations
       content:
@@ -5226,8 +5380,10 @@ components:
             this is "true" then no Web API commands will be accepted by this device.
         name:
           type: string
-          example: Loudest speaker
-          description: The name of the device.
+          example: Kitchen speaker
+          description: A human-readable name for the device. Some devices have a name
+            that the user can configure (e.g. \"Loudest speaker\") and some devices
+            have a generic name associated with the manufacturer or device model.
         type:
           type: string
           example: computer
@@ -6086,6 +6242,132 @@ components:
       x-spotify-docs-type: SimplifiedShowObject
       allOf:
         - $ref: '#/components/schemas/ShowBase'
+    AudiobookBase:
+      type: object
+      required:
+        - authors
+        - available_markets
+        - copyrights
+        - description
+        - explicit
+        - external_urls
+        - href
+        - html_description
+        - id
+        - images
+        - languages
+        - media_type
+        - name
+        - narrators
+        - publisher
+        - total_chapters
+        - type
+        - uri
+      properties:
+        authors:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthorObject'
+          description: |
+            The author(s) for the audiobook.
+        available_markets:
+          type: array
+          items:
+            type: string
+          description: |
+            A list of the countries in which the audiobook can be played, identified by their [ISO 3166-1 alpha-2](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code.
+        copyrights:
+          type: array
+          items:
+            $ref: '#/components/schemas/CopyrightObject'
+          description: |
+            The copyright statements of the audiobook.
+        description:
+          type: string
+          description: |
+            A description of the audiobook. HTML tags are stripped away from this field, use `html_description` field in case HTML tags are needed.
+        html_description:
+          type: string
+          description: |
+            A description of the audiobook. This field may contain HTML tags.
+        explicit:
+          type: boolean
+          description: |
+            Whether or not the audiobook has explicit content (true = yes it does; false = no it does not OR unknown).
+        external_urls:
+          allOf:
+            - $ref: '#/components/schemas/ExternalUrlObject'
+          description: |
+            External URLs for this audiobook.
+        href:
+          type: string
+          description: |
+            A link to the Web API endpoint providing full details of the audiobook.
+        id:
+          type: string
+          description: |
+            The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids) for the audiobook.
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImageObject'
+          description: |
+            The cover art for the audiobook in various sizes, widest first.
+        languages:
+          type: array
+          items:
+            type: string
+          description: |
+            A list of the languages used in the audiobook, identified by their [ISO 639](https://en.wikipedia.org/wiki/ISO_639) code.
+        media_type:
+          type: string
+          description: |
+            The media type of the audiobook.
+        name:
+          type: string
+          description: |
+            The name of the audiobook.
+        narrators:
+          type: array
+          $ref: '#/components/schemas/NarratorObject'
+          description: |
+            The narrator(s) for the audiobook.
+        publisher:
+          type: string
+          description: |
+            The publisher of the audiobook.
+        type:
+          type: string
+          enum:
+            - audiobook
+          description: |
+            The object type.
+        uri:
+          type: string
+          description: |
+            The [Spotify URI](/documentation/web-api/#spotify-uris-and-ids) for the audiobook.
+        total_chapters:
+          type: integer
+          description: |
+            The number of chapters in this audiobook.
+    AudiobookObject:
+      x-spotify-docs-type: AudiobookObject
+      allOf:
+        - $ref: '#/components/schemas/AudiobookBase'
+        - type: object
+          required:
+            - chapters
+          properties:
+            chapters:
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/ChaptersPagingObject'
+              description: |
+                The chapters of the audiobook.
+    SimplifiedAudiobookObject:
+      x-spotify-docs-type: SimplifiedAudiobookObject
+      allOf:
+        - $ref: '#/components/schemas/AudiobookBase'
     AlbumBase:
       type: object
       required:
@@ -6203,6 +6485,153 @@ components:
                 $ref: '#/components/schemas/SimplifiedArtistObject'
               description: |
                 The artists of the album. Each artist object includes a link in `href` to more detailed information about the artist.
+    ChapterObject:
+      x-spotify-docs-type: ChapterObject
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ChapterBase'
+        - type: object
+          required:
+            - audiobook
+          properties:
+            audiobook:
+              $ref: '#/components/schemas/SimplifiedAudiobookObject'
+              description: |
+                The audiobook for which the chapter belongs.
+    SimplifiedChapterObject:
+      x-spotify-docs-type: SimplifiedChapterObject
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ChapterBase'
+    ChapterBase:
+      type: object
+      required:
+        - audio_preview_url
+        - chapter_number
+        - description
+        - html_description
+        - duration_ms
+        - explicit
+        - external_urls
+        - href
+        - id
+        - images
+        - is_playable
+        - languages
+        - name
+        - release_date
+        - release_date_precision
+        - resume_point
+        - type
+        - uri
+      properties:
+        audio_preview_url:
+          type: string
+          example: https://p.scdn.co/mp3-preview/2f37da1d4221f40b9d1a98cd191f4d6f1646ad17
+          description: |
+            A URL to a 30 second preview (MP3 format) of the episode. `null` if not available.
+        chapter_number:
+          type: integer
+          example: 1
+          description: |
+            The number of the chapter
+        description:
+          type: string
+          example: |
+            A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.
+          description: |
+            A description of the episode. HTML tags are stripped away from this field, use `html_description` field in case HTML tags are needed.
+        html_description:
+          type: string
+          example: |
+            <p>A Spotify podcast sharing fresh insights on important topics of the moment—in a way only Spotify can. You’ll hear from experts in the music, podcast and tech industries as we discover and uncover stories about our work and the world around us.</p>
+          description: |
+            A description of the episode. This field may contain HTML tags.
+        duration_ms:
+          type: integer
+          example: 1686230
+          description: |
+            The episode length in milliseconds.
+        explicit:
+          type: boolean
+          description: |
+            Whether or not the episode has explicit content (true = yes it does; false = no it does not OR unknown).
+        external_urls:
+          allOf:
+            - $ref: '#/components/schemas/ExternalUrlObject'
+          description: |
+            External URLs for this episode.
+        href:
+          type: string
+          example: https://api.spotify.com/v1/episodes/5Xt5DXGzch68nYYamXrNxZ
+          description: |
+            A link to the Web API endpoint providing full details of the episode.
+        id:
+          type: string
+          example: 5Xt5DXGzch68nYYamXrNxZ
+          description: |
+            The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids) for the episode.
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImageObject'
+          description: |
+            The cover art for the episode in various sizes, widest first.
+        is_playable:
+          type: boolean
+          description: |
+            True if the episode is playable in the given market. Otherwise false.
+        languages:
+          type: array
+          items:
+            type: string
+          example:
+            - fr
+            - en
+          description: |
+            A list of the languages used in the episode, identified by their [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639) code.
+        name:
+          type: string
+          example: |
+            Starting Your Own Podcast: Tips, Tricks, and Advice From Anchor Creators
+          description: |
+            The name of the episode.
+        release_date:
+          type: string
+          example: 1981-12-15
+          description: |
+            The date the episode was first released, for example `"1981-12-15"`. Depending on the precision, it might be shown as `"1981"` or `"1981-12"`.
+        release_date_precision:
+          type: string
+          example: day
+          enum:
+            - year
+            - month
+            - day
+          description: |
+            The precision with which `release_date` value is known.
+        resume_point:
+          allOf:
+            - $ref: '#/components/schemas/ResumePointObject'
+          description: |
+            The user's most recent position in the episode. Set if the supplied access token is a user token and has the scope 'user-read-playback-position'.
+        type:
+          type: string
+          enum:
+            - episode
+          description: |
+            The object type.
+        uri:
+          type: string
+          example: spotify:episode:0zLhl3WsOCQHbe1BPTiHgr
+          description: |
+            The [Spotify URI](/documentation/web-api/#spotify-uris-and-ids) for the episode.
+        restrictions:
+          allOf:
+            - $ref: '#/components/schemas/EpisodeRestrictionObject'
+          description: |
+            Included in the response when a content restriction is applied.
+            See [Restriction Object](/documentation/web-api/reference/#object-episoderestrictionobject) for more details.
     AlbumObject:
       x-spotify-docs-type: AlbumObject
       allOf:
@@ -6277,6 +6706,22 @@ components:
           type: string
           description: |
             The type of copyright: `C` = the copyright, `P` = the sound recording (performance) copyright.
+    AuthorObject:
+      type: object
+      x-spotify-docs-type: AuthorObject
+      properties:
+        name:
+          type: string
+          description: |
+            The name of the author.
+    NarratorObject:
+      type: object
+      x-spotify-docs-type: NarratorObject
+      properties:
+        name:
+          type: string
+          description: |
+            The name of the Narrator.
     ExternalIdObject:
       type: object
       x-spotify-docs-type: ExternalIdObject
@@ -6370,6 +6815,24 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/ArtistObject'
+    AudiobooksPagingObject:
+      allOf:
+        - $ref: '#/components/schemas/PagingObject'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/SimplifiedAudiobookObject'
+    ChaptersPagingObject:
+      allOf:
+        - $ref: '#/components/schemas/PagingObject'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/SimplifiedChapterObject'
     EpisodesPagingObject:
       allOf:
         - $ref: '#/components/schemas/PagingObject'
@@ -6534,6 +6997,48 @@ components:
           The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids)
           for the show.
         example: 38bS44xjbVVZ3No3ByF1dJ
+        type: string
+    PathAudiobookId:
+      name: id
+      required: true
+      in: path
+      schema:
+        title: Spotify Audiobook ID
+        description: |
+          The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids)
+          for the audiobook.
+        example: 38bS44xjbVVZ3No3ByF1dJ
+        type: string
+    QueryAudiobookIds:
+      name: ids
+      required: true
+      in: query
+      schema:
+        title: Spotify Audiobook IDs
+        description: |
+          A comma-separated list of the [Spotify IDs](/documentation/web-api/#spotify-uris-and-ids). For example: `ids=4iV5W9uYEdYUVa79Axb7Rh,1301WleyT98MSxVHPZCA6M`. Maximum: 50 IDs.
+        example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
+        type: string
+    PathChapterId:
+      name: id
+      required: true
+      in: path
+      schema:
+        title: Spotify Chapter ID
+        description: |
+          The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids)
+          for the chapter.
+        example: 38bS44xjbVVZ3No3ByF1dJ
+        type: string
+    QueryChapterIds:
+      name: ids
+      required: true
+      in: query
+      schema:
+        title: Spotify Chapter IDs
+        description: |
+          A comma-separated list of the [Spotify IDs](/documentation/web-api/#spotify-uris-and-ids). For example: `ids=4iV5W9uYEdYUVa79Axb7Rh,1301WleyT98MSxVHPZCA6M`. Maximum: 50 IDs.
+        example: "7ouMYWpwJ422jRcDASZB7P,4VqPOruhp5EdPBeR92t6lQ,2takcwOaAZWiXQijPHIx7B"
         type: string
     QueryTrackIds:
       name: ids

--- a/spotify-graphql-schema-generator/src/main/java/de/sonallux/spotify/graphql/schema/Mapping.java
+++ b/spotify-graphql-schema-generator/src/main/java/de/sonallux/spotify/graphql/schema/Mapping.java
@@ -7,7 +7,9 @@ public sealed interface Mapping permits FieldMapping, TypeMapping, BaseTypeQuery
     enum Category {
         ALBUM,
         ARTIST,
+        AUDIOBOOK,
         BROWSE,
+        CHAPTER,
         CORE,
         EPISODE,
         LIBRARY,

--- a/spotify-graphql-schema-generator/src/main/java/de/sonallux/spotify/graphql/schema/Mappings.java
+++ b/spotify-graphql-schema-generator/src/main/java/de/sonallux/spotify/graphql/schema/Mappings.java
@@ -27,12 +27,16 @@ public final class Mappings {
             new TypeMapping("AlbumsPagingObject", Mapping.Category.ALBUM),
             new FieldMapping("AlbumObject", "tracks", "/albums/{id}/tracks", Mapping.Category.ALBUM),
 
+            new BaseTypeQueryMapping(TypeMapping.Category.AUDIOBOOK),
             new TypeMapping("AudiobooksPagingObject", Mapping.Category.AUDIOBOOK),
 
+            new BaseTypeQueryMapping(TypeMapping.Category.CHAPTER),
             new TypeMapping("ChaptersPagingObject", Mapping.Category.CHAPTER),
 
             new BaseTypeQueryMapping(Mapping.Category.EPISODE),
             new TypeMapping("EpisodesPagingObject", Mapping.Category.EPISODE),
+            new TypeMapping("EpisodeRestrictionObject", Mapping.Category.EPISODE),
+            new TypeMapping("ResumePointObject", Mapping.Category.EPISODE),
 
             new BaseTypeQueryMapping(Mapping.Category.PLAYLIST),
             new TypeMapping("PlaylistsPagingObject", Mapping.Category.PLAYLIST),

--- a/spotify-graphql-schema-generator/src/main/java/de/sonallux/spotify/graphql/schema/Mappings.java
+++ b/spotify-graphql-schema-generator/src/main/java/de/sonallux/spotify/graphql/schema/Mappings.java
@@ -27,6 +27,10 @@ public final class Mappings {
             new TypeMapping("AlbumsPagingObject", Mapping.Category.ALBUM),
             new FieldMapping("AlbumObject", "tracks", "/albums/{id}/tracks", Mapping.Category.ALBUM),
 
+            new TypeMapping("AudiobooksPagingObject", Mapping.Category.AUDIOBOOK),
+
+            new TypeMapping("ChaptersPagingObject", Mapping.Category.CHAPTER),
+
             new BaseTypeQueryMapping(Mapping.Category.EPISODE),
             new TypeMapping("EpisodesPagingObject", Mapping.Category.EPISODE),
 

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/ArtistController.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/ArtistController.java
@@ -22,7 +22,7 @@ public class ArtistController extends BaseController {
 
     @QueryMapping
     Mono<List<Map<String, Object>>> artists(@Nullable @Argument List<String> ids, @Nullable @Argument List<String> uris,
-                                           DataLoader<String, Map<String, Object>> artistLoader
+                                            DataLoader<String, Map<String, Object>> artistLoader
     ) {
         return loadMany(ids, uris, "artist", artistLoader);
     }

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/AudiobookController.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/AudiobookController.java
@@ -1,0 +1,28 @@
+package de.sonallux.spotify.graphql.controller;
+
+import org.dataloader.DataLoader;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+@Controller
+public class AudiobookController extends BaseController {
+    @QueryMapping
+    Mono<Map<String, Object>> audiobook(@Nullable @Argument String id, @Nullable @Argument String uri,
+                                        DataLoader<String, Map<String, Object>> audiobookLoader
+    ) {
+        return load(id, uri, "audiobook", audiobookLoader);
+    }
+
+    @QueryMapping
+    Mono<List<Map<String, Object>>> audiobooks(@Nullable @Argument List<String> ids, @Nullable @Argument List<String> uris,
+                                               DataLoader<String, Map<String, Object>> audiobookLoader
+    ) {
+        return loadMany(ids, uris, "audiobook", audiobookLoader);
+    }
+}

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/BaseController.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/BaseController.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 abstract class BaseController {
 
     Mono<Map<String, Object>> load(@Nullable String id, @Nullable String uri, String type,
-                                             DataLoader<String, Map<String, Object>> dataloader) {
+                                   DataLoader<String, Map<String, Object>> dataloader) {
         return Mono.fromSupplier(() -> extractSpotifyId(id, uri, type))
             .flatMap(actualId -> Mono.fromFuture(dataloader.load(actualId)));
     }

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/ChapterController.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/ChapterController.java
@@ -1,0 +1,28 @@
+package de.sonallux.spotify.graphql.controller;
+
+import org.dataloader.DataLoader;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+@Controller
+public class ChapterController extends BaseController {
+    @QueryMapping
+    Mono<Map<String, Object>> chapter(@Nullable @Argument String id, @Nullable @Argument String uri,
+                                      DataLoader<String, Map<String, Object>> chapterLoader
+    ) {
+        return load(id, uri, "chapter", chapterLoader);
+    }
+
+    @QueryMapping
+    Mono<List<Map<String, Object>>> chapters(@Nullable @Argument List<String> ids, @Nullable @Argument List<String> uris,
+                                             DataLoader<String, Map<String, Object>> chapterLoader
+    ) {
+        return loadMany(ids, uris, "chapter", chapterLoader);
+    }
+}

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/EpisodeController.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/EpisodeController.java
@@ -14,14 +14,14 @@ import java.util.Map;
 public class EpisodeController extends BaseController {
     @QueryMapping
     Mono<Map<String, Object>> episode(@Nullable @Argument String id, @Nullable @Argument String uri,
-                                    DataLoader<String, Map<String, Object>> episodeLoader
+                                      DataLoader<String, Map<String, Object>> episodeLoader
     ) {
         return load(id, uri, "episode", episodeLoader);
     }
 
     @QueryMapping
     Mono<List<Map<String, Object>>> episodes(@Nullable @Argument List<String> ids, @Nullable @Argument List<String> uris,
-                                           DataLoader<String, Map<String, Object>> episodeLoader
+                                             DataLoader<String, Map<String, Object>> episodeLoader
     ) {
         return loadMany(ids, uris, "episode", episodeLoader);
     }

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/ShowController.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/controller/ShowController.java
@@ -15,14 +15,14 @@ import java.util.Map;
 public class ShowController extends BaseController {
     @QueryMapping
     Mono<Map<String, Object>> show(@Nullable @Argument String id, @Nullable @Argument String uri,
-                                    DataLoader<String, Map<String, Object>> showLoader
+                                   DataLoader<String, Map<String, Object>> showLoader
     ) {
         return load(id, uri, "show", showLoader);
     }
 
     @QueryMapping
     Mono<List<Map<String, Object>>> shows(@Nullable @Argument List<String> ids, @Nullable @Argument List<String> uris,
-                                           DataLoader<String, Map<String, Object>> showLoader
+                                          DataLoader<String, Map<String, Object>> showLoader
     ) {
         return loadMany(ids, uris, "show", showLoader);
     }

--- a/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/wiring/SpotifyObjectTypeResolver.java
+++ b/spotify-graphql-server/src/main/java/de/sonallux/spotify/graphql/wiring/SpotifyObjectTypeResolver.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class SpotifyObjectTypeResolver implements TypeResolver {
 
-    private static final List<String> SPOTIFY_BASE_OBJECT_TYPE_NAMES = List.of("Album", "Artist", "Episode", "Playlist", "Show", "Track");
+    private static final List<String> SPOTIFY_BASE_OBJECT_TYPE_NAMES = List.of("Album", "Artist", "Audiobook", "Chapter", "Episode", "Playlist", "Show", "Track");
 
     public boolean canResolveUnionType(UnionTypeDefinition unionTypeDefinition) {
         return unionTypeDefinition.getMemberTypes().stream().allMatch(type -> {

--- a/spotify-graphql-server/src/main/resources/graphql/audiobook.graphqls
+++ b/spotify-graphql-server/src/main/resources/graphql/audiobook.graphqls
@@ -1,0 +1,67 @@
+type Audiobook {
+  "The author(s) for the audiobook."
+  authors: [Author]
+  "A list of the countries in which the audiobook can be played, identified by their [ISO 3166-1 alpha-2](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) code."
+  available_markets: [String]
+  "The chapters of the audiobook."
+  chapters: ChaptersPaging
+  "The copyright statements of the audiobook."
+  copyrights: [Copyright]
+  "A description of the audiobook. HTML tags are stripped away from this field, use `html_description` field in case HTML tags are needed."
+  description: String
+  "Whether or not the audiobook has explicit content (true = yes it does; false = no it does not OR unknown)."
+  explicit: Boolean
+  "External URLs for this audiobook."
+  external_urls: ExternalUrl
+  "A link to the Web API endpoint providing full details of the audiobook."
+  href: String
+  "A description of the audiobook. This field may contain HTML tags."
+  html_description: String
+  "The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids) for the audiobook."
+  id: String
+  "The cover art for the audiobook in various sizes, widest first."
+  images: [Image]
+  "A list of the languages used in the audiobook, identified by their [ISO 639](https://en.wikipedia.org/wiki/ISO_639) code."
+  languages: [String]
+  "The media type of the audiobook."
+  media_type: String
+  "The name of the audiobook."
+  name: String
+  narrators: Narrator
+  "The publisher of the audiobook."
+  publisher: String
+  "The number of chapters in this audiobook."
+  total_chapters: Int
+  "The object type."
+  type: String
+  "The [Spotify URI](/documentation/web-api/#spotify-uris-and-ids) for the audiobook."
+  uri: String
+}
+
+type AudiobooksPaging {
+  "A link to the Web API endpoint returning the full result of the request"
+  href: String
+  "The requested content"
+  items: [Audiobook]
+  "The maximum number of items in the response (as set in the query or by default)."
+  limit: Int
+  "URL to the next page of items. ( `null` if none)"
+  next: String
+  "The offset of the items returned (as set in the query or by default)"
+  offset: Int
+  "URL to the previous page of items. ( `null` if none)"
+  previous: String
+  "The total number of items available to return."
+  total: Int
+}
+
+type Author {
+  "The name of the author."
+  name: String
+}
+
+type Narrator {
+  "The name of the Narrator."
+  name: String
+}
+

--- a/spotify-graphql-server/src/main/resources/graphql/audiobook.graphqls
+++ b/spotify-graphql-server/src/main/resources/graphql/audiobook.graphqls
@@ -1,3 +1,18 @@
+extend type Query {
+  audiobook(
+    "The Spotify ID of the object to query. Either `id` or `uri` must be specified"
+    id: String, 
+    "The Spotify URI of the object to query. Either `id` or `uri` must be specified"
+    uri: String
+  ): Audiobook
+  audiobooks(
+    "A list of Spotify IDs of the objects to query. Either `ids` or `uris` must be specified"
+    ids: [String], 
+    "A list of Spotify URIs of the objects to query. Either `ids` or `uris` must be specified"
+    uris: [String]
+  ): [Audiobook]
+}
+
 type Audiobook {
   "The author(s) for the audiobook."
   authors: [Author]

--- a/spotify-graphql-server/src/main/resources/graphql/chapter.graphqls
+++ b/spotify-graphql-server/src/main/resources/graphql/chapter.graphqls
@@ -1,3 +1,18 @@
+extend type Query {
+  chapter(
+    "The Spotify ID of the object to query. Either `id` or `uri` must be specified"
+    id: String, 
+    "The Spotify URI of the object to query. Either `id` or `uri` must be specified"
+    uri: String
+  ): Chapter
+  chapters(
+    "A list of Spotify IDs of the objects to query. Either `ids` or `uris` must be specified"
+    ids: [String], 
+    "A list of Spotify URIs of the objects to query. Either `ids` or `uris` must be specified"
+    uris: [String]
+  ): [Chapter]
+}
+
 type Chapter {
   "A URL to a 30 second preview (MP3 format) of the episode. `null` if not available."
   audio_preview_url: String

--- a/spotify-graphql-server/src/main/resources/graphql/chapter.graphqls
+++ b/spotify-graphql-server/src/main/resources/graphql/chapter.graphqls
@@ -1,0 +1,62 @@
+type Chapter {
+  "A URL to a 30 second preview (MP3 format) of the episode. `null` if not available."
+  audio_preview_url: String
+  audiobook: Audiobook
+  "The number of the chapter"
+  chapter_number: Int
+  "A description of the episode. HTML tags are stripped away from this field, use `html_description` field in case HTML tags are needed."
+  description: String
+  "The episode length in milliseconds."
+  duration_ms: Int
+  "Whether or not the episode has explicit content (true = yes it does; false = no it does not OR unknown)."
+  explicit: Boolean
+  "External URLs for this episode."
+  external_urls: ExternalUrl
+  "A link to the Web API endpoint providing full details of the episode."
+  href: String
+  "A description of the episode. This field may contain HTML tags."
+  html_description: String
+  "The [Spotify ID](/documentation/web-api/#spotify-uris-and-ids) for the episode."
+  id: String
+  "The cover art for the episode in various sizes, widest first."
+  images: [Image]
+  "True if the episode is playable in the given market. Otherwise false."
+  is_playable: Boolean
+  "A list of the languages used in the episode, identified by their [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639) code."
+  languages: [String]
+  "The name of the episode."
+  name: String
+  "The date the episode was first released, for example `\"1981-12-15\"`. Depending on the precision, it might be shown as `\"1981\"` or `\"1981-12\"`."
+  release_date: String
+  "The precision with which `release_date` value is known."
+  release_date_precision: String
+  """
+  Included in the response when a content restriction is applied.
+  See [Restriction Object](/documentation/web-api/reference/#object-episoderestrictionobject) for more details.
+  """
+  restrictions: EpisodeRestriction
+  "The user's most recent position in the episode. Set if the supplied access token is a user token and has the scope 'user-read-playback-position'."
+  resume_point: ResumePoint
+  "The object type."
+  type: String
+  "The [Spotify URI](/documentation/web-api/#spotify-uris-and-ids) for the episode."
+  uri: String
+}
+
+type ChaptersPaging {
+  "A link to the Web API endpoint returning the full result of the request"
+  href: String
+  "The requested content"
+  items: [Chapter]
+  "The maximum number of items in the response (as set in the query or by default)."
+  limit: Int
+  "URL to the next page of items. ( `null` if none)"
+  next: String
+  "The offset of the items returned (as set in the query or by default)"
+  offset: Int
+  "URL to the previous page of items. ( `null` if none)"
+  previous: String
+  "The total number of items available to return."
+  total: Int
+}
+

--- a/spotify-graphql-server/src/main/resources/graphql/core.graphqls
+++ b/spotify-graphql-server/src/main/resources/graphql/core.graphqls
@@ -76,6 +76,7 @@ type Image {
 type SearchItems {
   albums: AlbumsPaging
   artists: ArtistsPaging
+  audiobooks: AudiobooksPaging
   episodes: EpisodesPaging
   playlists: PlaylistsPaging
   shows: ShowsPaging


### PR DESCRIPTION
- Update fixed-spotify-open-api.yml to `2022.9.27`
- Add audiobook and chapter as category
- Add base queries for audiobook and chapter

Note: Queries for audiobooks and chapters are only possible for the US market. Either the user's locale must be set to the US or the market parameter must be used. The market parameter is currently not supported by this GraphQL wrapper (see #68)